### PR TITLE
Use GNOME Platform 42 and remove libadwaita from manifest

### DIFF
--- a/io.github.WojtekWidomski.comparator.json
+++ b/io.github.WojtekWidomski.comparator.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.WojtekWidomski.comparator",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "master",
+    "runtime-version" : "42",
     "appstream-compose" : false,
     "sdk" : "org.gnome.Sdk",
     "command" : "comparator",
@@ -24,51 +24,6 @@
         "*.a"
     ],
     "modules" : [
-        {
-            "name" : "libadwaita",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dexamples=false",
-                "-Dtests=false"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "tag" : "1.0.1"
-                }
-            ],
-            "modules" : [
-                {
-                    "name" : "libsass",
-                    "buildsystem" : "meson",
-                    "cleanup" : [
-                        "*"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "git",
-                            "url" : "https://github.com/lazka/libsass.git",
-                            "branch" : "meson"
-                        }
-                    ]
-                },
-                {
-                    "name" : "sassc",
-                    "buildsystem" : "meson",
-                    "cleanup" : [
-                        "*"
-                    ],
-                    "sources" : [
-                        {
-                            "type" : "git",
-                            "url" : "https://github.com/lazka/sassc.git",
-                            "branch" : "meson"
-                        }
-                    ]
-                }
-            ]
-        },
         {
             "name" : "python3-mcstatus",
             "buildsystem" : "simple",


### PR DESCRIPTION
Libadwaita is now included in GNOME Platform.